### PR TITLE
add missing overload for VertexBuffer

### DIFF
--- a/src/csfml/graphics.nim
+++ b/src/csfml/graphics.nim
@@ -280,6 +280,7 @@ defDraw Shape
 defDraw Sprite
 defDraw Text
 defDraw VertexArray
+defDraw VertexBuffer
 
 proc draw*[T: RenderTexture|RenderWindow, O] (
   renderTarget: T, obj: O, states = renderStates()) =


### PR DESCRIPTION
Seems like it was just that one line missing. VertexBuffers worked fine in my tests.

Fixes #20 